### PR TITLE
実行時エラーでも行数と列数を表示する

### DIFF
--- a/MarineLang/Models/Asts/ExprAsts.cs
+++ b/MarineLang/Models/Asts/ExprAsts.cs
@@ -85,10 +85,11 @@ namespace MarineLang.Models.Asts
     public class VariableAst : ExprAst
     {
         public string varName;
+        public Position position;
 
-        public static VariableAst Create(string varName)
+        public static VariableAst Create(string varName, Position position)
         {
-            return new VariableAst { varName = varName };
+            return new VariableAst { varName = varName, position = position };
         }
 
         public override IEnumerable<T> LookUp<T>()
@@ -176,14 +177,14 @@ namespace MarineLang.Models.Asts
     public class InstanceFieldAst : ExprAst
     {
         public ExprAst instanceExpr;
-        public string fieldName;
+        public VariableAst variableAst;
 
-        public static InstanceFieldAst Create(ExprAst instanceExpr, string fieldName)
+        public static InstanceFieldAst Create(ExprAst instanceExpr, VariableAst variableAst)
         {
             return new InstanceFieldAst
             {
                 instanceExpr = instanceExpr,
-                fieldName = fieldName
+                variableAst = variableAst
             };
         }
 
@@ -292,10 +293,11 @@ namespace MarineLang.Models.Asts
     {
         public string funcName;
         public ExprAst[] args;
+        public Position position;
 
-        public static FuncCallAst Create(string funcName, ExprAst[] args)
+        public static FuncCallAst Create(string funcName, ExprAst[] args, Position position)
         {
-            return new FuncCallAst { funcName = funcName, args = args };
+            return new FuncCallAst { funcName = funcName, args = args, position = position };
         }
 
         public override IEnumerable<T> LookUp<T>()

--- a/MarineLang/Models/Asts/StatementAsts.cs
+++ b/MarineLang/Models/Asts/StatementAsts.cs
@@ -123,11 +123,11 @@ namespace MarineLang.Models.Asts
     {
         public ExprAst expr;
         public ExprAst instanceExpr;
-        public string fieldName;
+        public VariableAst variableAst;
 
-        public static FieldAssignmentAst Create(string fieldName, ExprAst instanceExpr, ExprAst expr)
+        public static FieldAssignmentAst Create(VariableAst variableAst, ExprAst instanceExpr, ExprAst expr)
         {
-            return new FieldAssignmentAst { fieldName = fieldName, instanceExpr = instanceExpr, expr = expr };
+            return new FieldAssignmentAst { variableAst = variableAst, instanceExpr = instanceExpr, expr = expr };
         }
 
         public override IEnumerable<T> LookUp<T>()

--- a/MarineLang/Models/Errors/RuntimeErrorInfo.cs
+++ b/MarineLang/Models/Errors/RuntimeErrorInfo.cs
@@ -6,14 +6,17 @@ namespace MarineLang.Models.Errors
     [Serializable()]
     public class RuntimeErrorInfo
     {
-        string prefixErrorMessage = "";
+        readonly string prefixErrorMessage = "";
 
-        public string ErrorMessage => prefixErrorMessage + ErrorCode.ToErrorMessage();
+        public readonly Position? errorPosition;
+
+        public string ErrorMessage => prefixErrorMessage + ErrorCode.ToErrorMessage() + $" \n {errorPosition} \nerror code: {(int)ErrorCode}";
         public ErrorCode ErrorCode { get; }
 
-        public RuntimeErrorInfo(string prefixErrorMessage, ErrorCode errorCode = ErrorCode.Unknown)
+        public RuntimeErrorInfo(string prefixErrorMessage, ErrorCode errorCode = ErrorCode.Unknown, Position? errorPosition = null)
         {
             this.prefixErrorMessage = prefixErrorMessage;
+            this.errorPosition = errorPosition;
             ErrorCode = errorCode;
         }
     }

--- a/MarineLang/SyntaxAnalysis/SyntaxAnalyzer.cs
+++ b/MarineLang/SyntaxAnalysis/SyntaxAnalyzer.cs
@@ -276,7 +276,7 @@ namespace MarineLang.SyntaxAnalysis
                                   ParserCombinator.Try(ParseFuncCall)
                                       .MapResult(funcCallAst => InstanceFuncCallAst.Create(instance, funcCallAst)),
                                   ParseVariable()
-                                      .MapResult(variableAst => InstanceFieldAst.Create(instance, variableAst.varName))
+                                      .MapResult(variableAst => InstanceFieldAst.Create(instance, variableAst))
                           )
                       );
             return stream =>
@@ -359,7 +359,7 @@ namespace MarineLang.SyntaxAnalysis
                 .Bind(funcNameToken =>
                     ParserCombinator.Try(ParseParamList)
                     .MapResult(paramList =>
-                        new FuncCallAst { funcName = funcNameToken.text, args = paramList }
+                        new FuncCallAst { funcName = funcNameToken.text, args = paramList, position = funcNameToken.position }
                     )
                 )(stream);
         }
@@ -466,7 +466,9 @@ namespace MarineLang.SyntaxAnalysis
                       if (exprAst is InstanceFieldAst fieldAst)
                           return
                               ParseExpr()
-                              .MapResult(expr => FieldAssignmentAst.Create(fieldAst.fieldName, fieldAst.instanceExpr, expr));
+                              .MapResult(expr =>
+                                FieldAssignmentAst.Create(fieldAst.variableAst, fieldAst.instanceExpr, expr)
+                              );
 
                       if (exprAst is GetIndexerAst getIndexerAst)
                           return
@@ -524,7 +526,7 @@ namespace MarineLang.SyntaxAnalysis
         {
             return
                 ParseToken(TokenType.Id)
-                .MapResult(token => VariableAst.Create(token.text));
+                .MapResult(token => VariableAst.Create(token.text, token.position));
         }
 
         IParseResult<ExprAst[]> ParseParamList(TokenStream stream)

--- a/MarineLang/VirtualMachines/MarineIL.cs
+++ b/MarineLang/VirtualMachines/MarineIL.cs
@@ -50,11 +50,13 @@ namespace MarineLang.VirtualMachines
     {
         public readonly string funcName;
         public readonly int argCount;
+        public readonly ILDebugInfo iLDebugInfo;
 
-        public InstanceCSharpFuncCallIL(string funcName, int argCount)
+        public InstanceCSharpFuncCallIL(string funcName, int argCount, ILDebugInfo iLDebugInfo = null)
         {
             this.funcName = funcName;
             this.argCount = argCount;
+            this.iLDebugInfo = iLDebugInfo;
         }
 
         public void Run(LowLevelVirtualMachine vm)
@@ -77,7 +79,8 @@ namespace MarineLang.VirtualMachines
                 throw new MarineRuntimeException(
                     new RuntimeErrorInfo(
                         $"({funcName})",
-                        ErrorCode.RuntimeMemberAccessPrivate
+                        ErrorCode.RuntimeMemberAccessPrivate,
+                        iLDebugInfo.position
                     )
                 );
         }
@@ -91,10 +94,13 @@ namespace MarineLang.VirtualMachines
     public struct InstanceCSharpFieldLoadIL : IMarineIL
     {
         public readonly string fieldName;
+        public readonly ILDebugInfo iLDebugInfo;
 
-        public InstanceCSharpFieldLoadIL(string fieldName)
+
+        public InstanceCSharpFieldLoadIL(string fieldName, ILDebugInfo iLDebugInfo = null)
         {
             this.fieldName = fieldName;
+            this.iLDebugInfo = iLDebugInfo;
         }
 
         public void Run(LowLevelVirtualMachine vm)
@@ -112,7 +118,8 @@ namespace MarineLang.VirtualMachines
                     throw new MarineRuntimeException(
                         new RuntimeErrorInfo(
                             $"{fieldName}",
-                            ErrorCode.RuntimeMemberAccessPrivate
+                            ErrorCode.RuntimeMemberAccessPrivate,
+                            iLDebugInfo.position
                         )
                     );
             }
@@ -126,7 +133,8 @@ namespace MarineLang.VirtualMachines
                     throw new MarineRuntimeException(
                         new RuntimeErrorInfo(
                             $"({fieldName})",
-                            ErrorCode.RuntimeMemberAccessPrivate
+                            ErrorCode.RuntimeMemberAccessPrivate,
+                            iLDebugInfo.position
                         )
                     );
             }
@@ -206,10 +214,12 @@ namespace MarineLang.VirtualMachines
     public struct InstanceCSharpFieldStoreIL : IMarineIL
     {
         public readonly string fieldName;
+        public readonly ILDebugInfo iLDebugInfo;
 
-        public InstanceCSharpFieldStoreIL(string fieldName)
+        public InstanceCSharpFieldStoreIL(string fieldName, ILDebugInfo iLDebugInfo = null)
         {
             this.fieldName = fieldName;
+            this.iLDebugInfo = iLDebugInfo;
         }
 
         public void Run(LowLevelVirtualMachine vm)
@@ -228,7 +238,8 @@ namespace MarineLang.VirtualMachines
                     throw new MarineRuntimeException(
                         new RuntimeErrorInfo(
                             $"({fieldName})",
-                            ErrorCode.RuntimeMemberAccessPrivate
+                            ErrorCode.RuntimeMemberAccessPrivate,
+                            iLDebugInfo.position
                         )
                     );
             }
@@ -242,7 +253,8 @@ namespace MarineLang.VirtualMachines
                     throw new MarineRuntimeException(
                         new RuntimeErrorInfo(
                             $"({fieldName})",
-                            ErrorCode.RuntimeMemberAccessPrivate
+                            ErrorCode.RuntimeMemberAccessPrivate,
+                            iLDebugInfo.position
                         )
                     );
             }

--- a/MarineLang/VirtualMachines/MarineIL.cs
+++ b/MarineLang/VirtualMachines/MarineIL.cs
@@ -9,6 +9,16 @@ using MarineLang.VirtualMachines.Attributes;
 
 namespace MarineLang.VirtualMachines
 {
+
+    public class ILDebugInfo
+    {
+        public readonly Position position;
+        public ILDebugInfo(Position position)
+        {
+            this.position = position;
+        }
+    }
+
     public interface IMarineIL
     {
         void Run(LowLevelVirtualMachine vm);

--- a/MarineLangUnitTest/VirtualMachineFailTest.cs
+++ b/MarineLangUnitTest/VirtualMachineFailTest.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Linq;
 using MarineLang.LexicalAnalysis;
+using MarineLang.Models;
 using MarineLang.Models.Errors;
 using MarineLang.Streams;
 using MarineLang.SyntaxAnalysis;
@@ -62,18 +62,19 @@ namespace MarineLangUnitTest
         }
 
         [Theory]
-        [InlineData("fun main() let fuga = create_fuga() ret fuga.member1 end ", 12)]
-        [InlineData("fun main() let fuga = create_fuga() fuga.member1 = 20 ret fuga.member1 end ", 20)]
-        [InlineData("fun main() let fuga = create_fuga() ret fuga.member2 end ", "hello")]
-        [InlineData("fun main() let fuga = create_fuga() fuga.member2 = \"hello2\" ret fuga.member2 end ", "hello2")]
-        [InlineData("fun main() let fuga = create_fuga() ret fuga.member3[0] end ", "hello")]
+        [InlineData("fun main() let fuga = create_fuga() ret fuga.member1 end ", 12, 1, 46)]
+        [InlineData("fun main() let fuga = create_fuga() fuga.member1 = 20 ret fuga.member1 end ", 20, 1, 42)]
+        [InlineData("fun main() let fuga = create_fuga() ret fuga.member2 end ", "hello", 1, 46)]
+        [InlineData("fun main() let fuga = create_fuga() fuga.member2 = \"hello2\" ret fuga.member2 end ", "hello2", 1, 42)]
+        [InlineData("fun main() let fuga = create_fuga() ret fuga.member3[0] end ", "hello", 1, 46)]
         [InlineData("fun main() let fuga = create_fuga() fuga.member3[0] = \"hello2\" ret fuga.member3[0] end ",
-            "hello2")]
-        [InlineData("fun main() let fuga = create_fuga() ret fuga.plus(2, 5) end ", 7)]
-        public void AccessibilityThrowTest<T>(string str, T expected)
+            "hello2", 1, 42)]
+        [InlineData("fun main() let fuga = create_fuga() ret fuga.plus(2, 5) end ", 7, 1, 46)]
+        public void AccessibilityThrowTest<T>(string str, T expected, int line = 0, int column = 0)
         {
             var exception = Assert.Throws<MarineRuntimeException>(() => RunReturnCheck(str, expected));
             Assert.Equal(ErrorCode.RuntimeMemberAccessPrivate, exception.RuntimeErrorInfo.ErrorCode);
+            Assert.Equal(new Position(line, column), exception.RuntimeErrorInfo.errorPosition);
         }
     }
 }


### PR DESCRIPTION
## 概要
実行時エラー(今はまだアクセシビリティのエラーだけ)にエラーしている行数と列数を表示できるように

## 変更内容
- VirtualMachineFailTestに正しいエラーの行数と列数が取得で来ているかのテスト追加
- ILに行数と列数の情報を保存
- ASTに行数と列数の情報を保存