### PR TITLE
ライブラリを使用しやすく

### DIFF
--- a/Example/Program.cs
+++ b/Example/Program.cs
@@ -42,7 +42,7 @@ namespace Example
 
         static void SetProgram(string code)
         {
-            var lexer = new Lexer();
+            var lexer = new LexicalAnalyzer();
 
             var tokens = lexer.GetTokens(code);
             Console.WriteLine("トークン解析結果");

--- a/Example/Program.cs
+++ b/Example/Program.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Linq;
 using System.Reflection;
 using System.IO;
 using MarineLang.LexicalAnalysis;
 using MarineLang.SyntaxAnalysis;
-using MarineLang.Streams;
 using MarineLang.VirtualMachines;
 
 namespace Example
@@ -52,9 +50,7 @@ namespace Example
             }
             Console.WriteLine("");
 
-            var tokenStream = TokenStream.Create(tokens.ToArray());
-
-            var parserResult = new SyntaxAnalyzer().Parse(tokenStream);
+            var parserResult = new SyntaxAnalyzer().Parse(tokens);
 
             if (parserResult.IsError)
             {

--- a/MarineLang/LexicalAnalysis/LexicalAnalyzer.cs
+++ b/MarineLang/LexicalAnalysis/LexicalAnalyzer.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace MarineLang.LexicalAnalysis
 {
-    public class Lexer
+    public class LexicalAnalyzer
     {
         public IEnumerable<Token> GetTokens(string str)
         {

--- a/MarineLang/SyntaxAnalysis/SyntaxAnalyzer.cs
+++ b/MarineLang/SyntaxAnalysis/SyntaxAnalyzer.cs
@@ -9,8 +9,9 @@ namespace MarineLang.SyntaxAnalysis
 {
     public class SyntaxAnalyzer
     {
-        public IParseResult<ProgramAst> Parse(TokenStream stream)
+        public IParseResult<ProgramAst> Parse(IEnumerable<Token> tokens)
         {
+            var stream = TokenStream.Create(tokens.ToArray());
             stream.MoveNext();
 
             return

--- a/MarineLang/VirtualMachines/HighLevelVirtualMachine.cs
+++ b/MarineLang/VirtualMachines/HighLevelVirtualMachine.cs
@@ -22,6 +22,11 @@ namespace MarineLang.VirtualMachines
             GlobalVariableRegister("action_object_generator", new ActionObjectGenerator(this));
         }
 
+        public bool ContainsMarineFunc(string funcName)
+        {
+            return ILGeneratedData?.funcILIndexDict?.ContainsKey(funcName) ?? false;
+        }
+
         public void GlobalFuncRegister(MethodInfo methodInfo)
         {
             methodInfoDict.Add(methodInfo.Name, methodInfo);

--- a/MarineLang/VirtualMachines/HighLevelVirtualMachine.cs
+++ b/MarineLang/VirtualMachines/HighLevelVirtualMachine.cs
@@ -8,13 +8,15 @@ namespace MarineLang.VirtualMachines
 {
     public class HighLevelVirtualMachine
     {
-        Dictionary<string, MethodInfo> methodInfoDict = new Dictionary<string, MethodInfo>();
-        SortedDictionary<string, object> globalVariableDict = new SortedDictionary<string, object>();
-        ILGeneratedData iLGeneratedData;
+        readonly Dictionary<string, MethodInfo> methodInfoDict = new Dictionary<string, MethodInfo>();
+        readonly SortedDictionary<string, object> globalVariableDict = new SortedDictionary<string, object>();
         ILGenerator iLGenerator;
 
-        public IReadOnlyList<IMarineIL> MarineILs => iLGeneratedData?.marineILs;
+        public ILGeneratedData ILGeneratedData { get; private set; }
+        public IReadOnlyDictionary<string, MethodInfo> GlobalFuncDict => methodInfoDict;
+        public IReadOnlyDictionary<string, object> GlobalVariableDict => globalVariableDict;
 
+        public IReadOnlyList<IMarineIL> MarineILs => ILGeneratedData?.marineILs;
         public HighLevelVirtualMachine()
         {
             GlobalVariableRegister("action_object_generator", new ActionObjectGenerator(this));
@@ -37,7 +39,7 @@ namespace MarineLang.VirtualMachines
 
         public void Compile()
         {
-            iLGeneratedData = iLGenerator.Generate(methodInfoDict, globalVariableDict.Keys.ToArray());
+            ILGeneratedData = iLGenerator.Generate(methodInfoDict, globalVariableDict.Keys.ToArray());
         }
 
         public RET Run<RET>(string marineFuncName, params object[] args)
@@ -49,7 +51,7 @@ namespace MarineLang.VirtualMachines
         {
             var lowLevelVirtualMachine = new LowLevelVirtualMachine();
             lowLevelVirtualMachine.Init();
-            lowLevelVirtualMachine.nextILIndex = iLGeneratedData.funcILIndexDict[marineFuncName];
+            lowLevelVirtualMachine.nextILIndex = ILGeneratedData.funcILIndexDict[marineFuncName];
             foreach (var val in globalVariableDict.Values)
                 lowLevelVirtualMachine.Push(val);
             lowLevelVirtualMachine.stackBaseCount = lowLevelVirtualMachine.GetStackCurrent();
@@ -57,7 +59,7 @@ namespace MarineLang.VirtualMachines
                 lowLevelVirtualMachine.Push(arg);
             lowLevelVirtualMachine.Push(lowLevelVirtualMachine.stackBaseCount);
             lowLevelVirtualMachine.Push(lowLevelVirtualMachine.nextILIndex + 1);
-            lowLevelVirtualMachine.Run(iLGeneratedData);
+            lowLevelVirtualMachine.Run(ILGeneratedData);
             if (lowLevelVirtualMachine.yieldFlag)
                 return (RET)YieldRun(lowLevelVirtualMachine);
             return (RET)lowLevelVirtualMachine.Pop();

--- a/MarineLangUnitTest/AstPassTest.cs
+++ b/MarineLangUnitTest/AstPassTest.cs
@@ -1,8 +1,6 @@
 using MarineLang.LexicalAnalysis;
 using MarineLang.Models.Asts;
-using MarineLang.Streams;
 using MarineLang.SyntaxAnalysis;
-using System.Linq;
 using Xunit;
 
 namespace MarineLangUnitTest
@@ -14,8 +12,7 @@ namespace MarineLangUnitTest
             var lexer = new LexicalAnalyzer();
             var parser = new SyntaxAnalyzer();
 
-            var tokenStream = TokenStream.Create(lexer.GetTokens(str).ToArray());
-            return parser.Parse(tokenStream);
+            return parser.Parse(lexer.GetTokens(str));
         }
 
         [Theory]

--- a/MarineLangUnitTest/AstPassTest.cs
+++ b/MarineLangUnitTest/AstPassTest.cs
@@ -11,7 +11,7 @@ namespace MarineLangUnitTest
     {
         public IParseResult<ProgramAst> ParseHelper(string str)
         {
-            var lexer = new Lexer();
+            var lexer = new LexicalAnalyzer();
             var parser = new SyntaxAnalyzer();
 
             var tokenStream = TokenStream.Create(lexer.GetTokens(str).ToArray());

--- a/MarineLangUnitTest/ParseErrorTest.cs
+++ b/MarineLangUnitTest/ParseErrorTest.cs
@@ -2,9 +2,7 @@
 using MarineLang.Models;
 using MarineLang.Models.Asts;
 using MarineLang.Models.Errors;
-using MarineLang.Streams;
 using MarineLang.SyntaxAnalysis;
-using System.Linq;
 using Xunit;
 
 namespace MarineLangUnitTest
@@ -16,8 +14,7 @@ namespace MarineLangUnitTest
             var lexer = new LexicalAnalyzer();
             var parser = new SyntaxAnalyzer();
 
-            var tokenStream = TokenStream.Create(lexer.GetTokens(str).ToArray());
-            return parser.Parse(tokenStream);
+            return parser.Parse(lexer.GetTokens(str));
         }
 
         internal void ErrorCheckHelper(string str, int line, int column, ErrorCode expectedErrorCode)

--- a/MarineLangUnitTest/ParseErrorTest.cs
+++ b/MarineLangUnitTest/ParseErrorTest.cs
@@ -13,7 +13,7 @@ namespace MarineLangUnitTest
     {
         public IParseResult<ProgramAst> ParseHelper(string str)
         {
-            var lexer = new Lexer();
+            var lexer = new LexicalAnalyzer();
             var parser = new SyntaxAnalyzer();
 
             var tokenStream = TokenStream.Create(lexer.GetTokens(str).ToArray());

--- a/MarineLangUnitTest/VirtualMachineFailTest.cs
+++ b/MarineLangUnitTest/VirtualMachineFailTest.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using MarineLang.LexicalAnalysis;
 using MarineLang.Models;
 using MarineLang.Models.Errors;
-using MarineLang.Streams;
 using MarineLang.SyntaxAnalysis;
 using MarineLang.VirtualMachines;
 using MarineLang.VirtualMachines.Attributes;
@@ -18,8 +17,7 @@ namespace MarineLangUnitTest
             var parser = new SyntaxAnalyzer();
 
             var tokens = lexer.GetTokens(str).ToArray();
-            var tokenStream = TokenStream.Create(tokens);
-            var parseResult = parser.Parse(tokenStream);
+            var parseResult = parser.Parse(tokens);
             if (parseResult.IsError)
                 return null;
             var vm = new HighLevelVirtualMachine();

--- a/MarineLangUnitTest/VirtualMachineFailTest.cs
+++ b/MarineLangUnitTest/VirtualMachineFailTest.cs
@@ -14,7 +14,7 @@ namespace MarineLangUnitTest
     {
         public HighLevelVirtualMachine VmCreateHelper(string str)
         {
-            var lexer = new Lexer();
+            var lexer = new LexicalAnalyzer();
             var parser = new SyntaxAnalyzer();
 
             var tokens = lexer.GetTokens(str).ToArray();

--- a/MarineLangUnitTest/VirtualMachinePassTest.cs
+++ b/MarineLangUnitTest/VirtualMachinePassTest.cs
@@ -15,7 +15,7 @@ namespace MarineLangUnitTest
     {
         public HighLevelVirtualMachine VmCreateHelper(string str)
         {
-            var lexer = new Lexer();
+            var lexer = new LexicalAnalyzer();
             var parser = new SyntaxAnalyzer();
 
             var tokens = lexer.GetTokens(str).ToArray();
@@ -37,7 +37,7 @@ namespace MarineLangUnitTest
             vm.GlobalFuncRegister(typeof(VirtualMachinePassTest).GetMethod(nameof(Wait5)));
             vm.GlobalFuncRegister(typeof(VirtualMachinePassTest).GetMethod(nameof(WaitWait5)));
             vm.GlobalVariableRegister("hoge", new Hoge());
-            vm.GlobalVariableRegister("names", new string[] {"aaa", "bbb"});
+            vm.GlobalVariableRegister("names", new string[] { "aaa", "bbb" });
             vm.GlobalVariableRegister("namess", new string[][]
             {
                 new string[] {"ccc", "ddd"},
@@ -63,7 +63,7 @@ namespace MarineLangUnitTest
         public class Hoge
         {
             public bool flag;
-            public string[] Names { get; } = new string[] {"rrr", "qqq"};
+            public string[] Names { get; } = new string[] { "rrr", "qqq" };
             public string Name { get; set; } = "this is the pen";
             public int PlusOne(int x) => x + 1;
             public Hoge GetThis() => this;
@@ -79,7 +79,7 @@ namespace MarineLangUnitTest
         {
             [MemberPublic] public int member1 = 12;
             [MemberPublic] public string Member2 { get; set; } = "hello";
-            [MemberPublic] public string[] Member3 { get; set; } = {"hello", "hello2"};
+            [MemberPublic] public string[] Member3 { get; set; } = { "hello", "hello2" };
 
             [MemberPublic]
             public int Plus(int a, int b)
@@ -442,8 +442,8 @@ end", 18)]
         }
 
         [Theory]
-        [InlineData("fun main() ret [0,1,3] end", new object[] {0, 1, 3})]
-        [InlineData("fun main() ret [7;3] end", new object[] {7, null, null})]
+        [InlineData("fun main() ret [0,1,3] end", new object[] { 0, 1, 3 })]
+        [InlineData("fun main() ret [7;3] end", new object[] { 7, null, null })]
         public void ArrayLiteral<T>(string str, T expected)
         {
             RunReturnCheck(str, expected);

--- a/MarineLangUnitTest/VirtualMachinePassTest.cs
+++ b/MarineLangUnitTest/VirtualMachinePassTest.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using MarineLang.BuildInObjects;
 using MarineLang.BuiltInTypes;
 using MarineLang.LexicalAnalysis;
-using MarineLang.Streams;
 using MarineLang.SyntaxAnalysis;
 using MarineLang.VirtualMachines;
 using MarineLang.VirtualMachines.Attributes;
@@ -19,8 +18,7 @@ namespace MarineLangUnitTest
             var parser = new SyntaxAnalyzer();
 
             var tokens = lexer.GetTokens(str).ToArray();
-            var tokenStream = TokenStream.Create(tokens);
-            var parseResult = parser.Parse(tokenStream);
+            var parseResult = parser.Parse(tokens);
             if (parseResult.IsError)
                 return null;
             var vm = new HighLevelVirtualMachine();


### PR DESCRIPTION
Lexerという名前はわかりずらいので、LexicalAnalyzerにした。
パースする時に、わざわざTokenStream作るの手間だったので、IEnumerableで受け取れるようにした。