### PR TITLE
マリン言語の実行結果の値をより扱いやすくした

### DIFF
--- a/MarineLang/BuildInObjects/ActionObject.cs
+++ b/MarineLang/BuildInObjects/ActionObject.cs
@@ -34,14 +34,14 @@ namespace MarineLang.BuildInObjects
         public object Get(int i) => captures[i];
         public void Set(int i, object obj) => captures[i] = obj;
 
-        public T InvokeGeneric<T>(params object[] args)
+        public MarineValue<T> InvokeGeneric<T>(params object[] args)
         {
             return vm.Run<T>(marineFuncName, new object[] { this }.Concat(args));
         }
 
-        public object Invoke(params object[] args)
+        public MarineValue Invoke(params object[] args)
         {
-            return vm.Run<object>(marineFuncName, new object[] { this }.Concat(args));
+            return vm.Run(marineFuncName, new object[] { this }.Concat(args));
         }
 
     }

--- a/MarineLang/VirtualMachines/HighLevelVirtualMachine.cs
+++ b/MarineLang/VirtualMachines/HighLevelVirtualMachine.cs
@@ -50,12 +50,22 @@ namespace MarineLang.VirtualMachines
             ILGeneratedData = iLGenerator.Generate(methodInfoDict, globalVariableDict.Keys.ToArray());
         }
 
-        public RET Run<RET>(string marineFuncName, params object[] args)
+        public MarineValue<RET> Run<RET>(string marineFuncName, params object[] args)
         {
             return Run<RET>(marineFuncName, args.AsEnumerable());
         }
 
-        public RET Run<RET>(string marineFuncName, IEnumerable<object> args)
+        public MarineValue Run(string marineFuncName, params object[] args)
+        {
+            return Run(marineFuncName, args.AsEnumerable());
+        }
+
+        public MarineValue<RET> Run<RET>(string marineFuncName, IEnumerable<object> args)
+        {
+            return new MarineValue<RET>( Run(marineFuncName, args));
+        }
+
+        public MarineValue Run(string marineFuncName, IEnumerable<object> args)
         {
             var lowLevelVirtualMachine = new LowLevelVirtualMachine();
             lowLevelVirtualMachine.Init();
@@ -69,8 +79,8 @@ namespace MarineLang.VirtualMachines
             lowLevelVirtualMachine.Push(lowLevelVirtualMachine.nextILIndex + 1);
             lowLevelVirtualMachine.Run(ILGeneratedData);
             if (lowLevelVirtualMachine.yieldFlag)
-                return (RET) YieldRun(lowLevelVirtualMachine);
-            return (RET) lowLevelVirtualMachine.Pop();
+                return new MarineValue(YieldRun(lowLevelVirtualMachine));
+            return new MarineValue(lowLevelVirtualMachine.Pop());
         }
 
         public void CreateDump()

--- a/MarineLang/VirtualMachines/MarineValue.cs
+++ b/MarineLang/VirtualMachines/MarineValue.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace MarineLang.VirtualMachines
+{
+    public class MarineValue
+    {
+        public object Value { get; }
+        public bool IsCoroutine { get; } = false;
+        public IEnumerable<object> Coroutine => coroutine;
+
+        readonly IEnumerable<object> coroutine;
+
+        public MarineValue(object value)
+        {
+            Value = value;
+        }
+
+        public MarineValue(IEnumerable<object> coroutine)
+        {
+            this.coroutine = coroutine;
+            IsCoroutine = true;
+        }
+
+        public object Eval()
+        {
+            return coroutine == null ? Value : coroutine.Last();
+        }
+    }
+
+    public class MarineValue<T>
+    {
+        public T Value { get; }
+        public bool IsCoroutine { get; }
+        public IEnumerable<T> Coroutine => coroutine;
+
+        readonly IEnumerable<T> coroutine;
+
+        public MarineValue(MarineValue marineValue)
+        {
+            if (marineValue.IsCoroutine)
+                coroutine = marineValue.Coroutine.Select(x => x == null ? default(T) : (T)x);
+            else
+                Value = (T)marineValue.Value;
+
+            IsCoroutine = marineValue.IsCoroutine;
+        }
+
+        public T Eval()
+        {
+            return coroutine == null ? Value : coroutine.Last();
+        }
+    }
+}

--- a/MarineLangUnitTest/Helper/VmCreateHelper.cs
+++ b/MarineLangUnitTest/Helper/VmCreateHelper.cs
@@ -136,7 +136,7 @@ namespace MarineLangUnitTest.Helper
 
         public static int InvokeInt(ActionObject actionObject, int val)
         {
-            return actionObject.InvokeGeneric<int>(val);
+            return actionObject.InvokeGeneric<int>(val).Value;
         }
 
         public static IEnumerator<int> Wait5()

--- a/MarineLangUnitTest/VirtualMachineFailTest.cs
+++ b/MarineLangUnitTest/VirtualMachineFailTest.cs
@@ -15,7 +15,7 @@ namespace MarineLangUnitTest
 
             var ret = vm.Run<RET>("main");
 
-            Assert.Equal(expected, ret);
+            Assert.Equal(expected, ret.Value);
         }
 
         [Theory]

--- a/MarineLangUnitTest/VirtualMachinePassTest.cs
+++ b/MarineLangUnitTest/VirtualMachinePassTest.cs
@@ -16,7 +16,7 @@ namespace MarineLangUnitTest
 
             var ret = vm.Run<RET>("main");
 
-            Assert.Equal(expected, ret);
+            Assert.Equal(expected, ret.Value);
         }
 
         [Theory]
@@ -143,7 +143,7 @@ fun f() let a=3 ret a end
 
             var ret = vm.Run<int>("main", 12, 8);
 
-            Assert.Equal(20, ret);
+            Assert.Equal(20, ret.Value);
         }
 
         [Theory]
@@ -387,9 +387,9 @@ fun main()
     let bb = 5
     let action = {|x| 
         bb=bb+1 
-        ret bb + x - aa+{ |y| ret x*y }.invoke([2])
+        ret bb + x - aa+{ |y| ret x*y }.invoke([2]).value
     }
-    ret action.invoke([8])+aa
+    ret action.invoke([8]).value+aa
 end
 ")]
         public void ActionObjectCall2(string str)
@@ -402,19 +402,19 @@ end
 fun main()
     ret {|f| 
         ret 
-            { |x| ret f.invoke( [{ |y| ret x.invoke([x]).invoke([y]) }] ) }
-            .invoke( [{|x| ret f.invoke( [{ |y| ret x.invoke([x]).invoke([y]) }] ) }] )   
+            { |x| ret f.invoke( [{ |y| ret x.invoke([x]).value.invoke([y]).value }] ).value }
+            .invoke( [{|x| ret f.invoke( [{ |y| ret x.invoke([x]).value.invoke([y]).value }] ).value }] ).value   
     }.invoke([
         { |f| 
             ret { |n| 
-                ret if n==0 {1} else {n * f.invoke([n - 1]) } 
+                ret if n==0 {1} else {n * f.invoke([n - 1]).value } 
             }
         } 
-    ]).invoke([5])
+    ]).value.invoke([5]).value
 end
 ")]
         [InlineData(@"
-fun main()ret{|f|ret{|x|ret f.invoke([{|y|ret x.invoke([x]).invoke([y])}])}.invoke([{|x|ret f.invoke([{|y|ret x.invoke([x]).invoke([y])}])}])}.invoke([{|f|ret{|n|ret if n==0{1}else{n*f.invoke([n-1])}}}]).invoke([5])end
+fun main()ret{|f|ret{|x|ret f.invoke([{|y|ret x.invoke([x]).value.invoke([y]).value}]).value}.invoke([{|x|ret f.invoke([{|y|ret x.invoke([x]).value.invoke([y]).value}]).value}]).value}.invoke([{|f|ret{|n|ret if n==0{1}else{n*f.invoke([n-1]).value}}}]).value.invoke([5]).value end
 ")]
         public void ActionObjectCall3(string str)
         {
@@ -430,9 +430,9 @@ fun main()ret{|f|ret{|x|ret f.invoke([{|y|ret x.invoke([x]).invoke([y])}])}.invo
 
             Assert.NotNull(vm);
 
-            var ret = vm.Run<IEnumerable<object>>("main");
+            var ret = vm.Run<T>("main");
 
-            var value = ret.ToArray().Last();
+            var value = ret.Eval();
 
             Assert.Equal(expected, value);
         }
@@ -448,9 +448,9 @@ fun main()ret{|f|ret{|x|ret f.invoke([{|y|ret x.invoke([x]).invoke([y])}])}.invo
 
             Assert.NotNull(vm);
 
-            var ret = vm.Run<IEnumerable<object>>("main");
+            var ret = vm.Run<T>("main");
 
-            var value = ret.ToArray().Last();
+            var value = ret.Eval();
 
             Assert.Equal(expected, value);
         }


### PR DESCRIPTION
今まで、マリン言語のコルーチン実行は、

`vm.Run<IEnumerable<object>>()`
でやる必要があった。

これからは

`vm.Run<コルーチンの最終的な返り値の型>()`となり、楽になった。

また、`Run`の結果は`MarineValue`という値にラップして返すようにした。

後、型指定が面倒な時用に、`Run`メソッドのNonジェネリクス版を用意しました。