### PR TITLE
関数を定義できる構文拡張マクロの実装&includeマクロの実装

### DIFF
--- a/MarineLang/LexicalAnalysis/LexerHelper.cs
+++ b/MarineLang/LexicalAnalysis/LexerHelper.cs
@@ -149,6 +149,20 @@ namespace MarineLang.LexicalAnalysis
              );
         }
 
+        static public Func<IndexedCharStream, Token> GetMacroNameToken()
+        {
+            return
+             GetTokenTest(TokenType.MacroName, (count, c) =>
+             {
+                 if (count == 0)
+                     return c == '#' ? TestResult.Pass : TestResult.End;
+                 if ((char.IsLetter(c) || char.IsDigit(c)) == false)
+                     return TestResult.End;
+                 return TestResult.Pass;
+             }
+             );
+        }
+
         static public Func<IndexedCharStream, Token> GetIntLiteralToken()
         {
             return

--- a/MarineLang/LexicalAnalysis/LexicalAnalyzer.cs
+++ b/MarineLang/LexicalAnalysis/LexicalAnalyzer.cs
@@ -61,6 +61,7 @@ namespace MarineLang.LexicalAnalysis
                     LexerHelper.GetCharToken(stream, TokenType.NotOp) ??
                     LexerHelper.GetIdToken()(stream) ??
                     LexerHelper.GetClassNameToken()(stream) ??
+                    LexerHelper.GetMacroNameToken()(stream) ??
                     LexerHelper.GetUnknownToken(stream);
 
                 if (stream.IsEnd == false)

--- a/MarineLang/MacroPlugins/IMacroPlugin.cs
+++ b/MarineLang/MacroPlugins/IMacroPlugin.cs
@@ -1,0 +1,14 @@
+﻿using MarineLang.Models;
+using MarineLang.Models.Asts;
+using MarineLang.SyntaxAnalysis;
+using System.Collections.Generic;
+
+namespace MarineLang.MacroPlugins
+{
+    public interface IMacroPlugin<T>
+    {
+        IParseResult<T> Replace(MarineParser marineParser, List<Token> tokens);
+    }
+
+    public interface IFuncDefinitionMacroPlugin : IMacroPlugin<IEnumerable<FuncDefinitionAst>> { }
+}

--- a/MarineLang/MacroPlugins/PluginContainer.cs
+++ b/MarineLang/MacroPlugins/PluginContainer.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace MarineLang.MacroPlugins
+{
+    public class PluginContainer
+    {
+        private readonly Dictionary<string, IFuncDefinitionMacroPlugin> funcDefinitionMacroPlugins
+            = new Dictionary<string, IFuncDefinitionMacroPlugin>();
+
+        public PluginContainer()
+        {
+
+        }
+
+        public void AddFuncDefinitionPlugin(string pluginName,IFuncDefinitionMacroPlugin funcDefinitionMacroPlugin)
+        {
+            funcDefinitionMacroPlugins.Add(pluginName, funcDefinitionMacroPlugin);
+        }
+
+        public IFuncDefinitionMacroPlugin GetFuncDefinitionPlugin(string pluginName)
+        {
+            return funcDefinitionMacroPlugins[pluginName];
+        }
+    }
+}

--- a/MarineLang/Models/TokenType.cs
+++ b/MarineLang/Models/TokenType.cs
@@ -5,6 +5,7 @@
         Func,
         Id,
         ClassName,
+        MacroName,
         Await,
         Yield,
         Break,

--- a/MarineLang/PresetMacroPlugins/IncludePlugin.cs
+++ b/MarineLang/PresetMacroPlugins/IncludePlugin.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using MarineLang.LexicalAnalysis;
+using MarineLang.MacroPlugins;
+using MarineLang.Models;
+using MarineLang.Models.Asts;
+using MarineLang.Streams;
+using MarineLang.SyntaxAnalysis;
+
+namespace MarineLang.PresetMacroPlugins
+{
+    public class IncludePlugin : IFuncDefinitionMacroPlugin
+    {
+        public IParseResult<IEnumerable<FuncDefinitionAst>> Replace(MarineParser marineParser, List<Token> tokens)
+        {
+            var str = "";
+            foreach (var token in tokens)
+            {
+                using (var sr = new StreamReader(token.text.Substring(1, token.text.Length - 2)))
+                {
+                    str += sr.ReadToEnd() + " ";
+                }
+            }
+
+            var tokens2 = new LexicalAnalyzer().GetTokens(str);
+
+            return
+                marineParser.ParseProgram(TokenStream.Create(tokens2.ToArray()))
+                .Map(programAst => programAst.funcDefinitionAsts);
+        }
+    }
+}

--- a/MarineLang/SyntaxAnalysis/SyntaxAnalyzer.cs
+++ b/MarineLang/SyntaxAnalysis/SyntaxAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using MarineLang.Models;
+﻿using MarineLang.MacroPlugins;
+using MarineLang.Models;
 using MarineLang.Models.Asts;
 using MarineLang.Streams;
 using System.Collections.Generic;
@@ -8,7 +9,15 @@ namespace MarineLang.SyntaxAnalysis
 {
     public class SyntaxAnalyzer
     {
-        public readonly MarineParser marineParser = new MarineParser();
+        public readonly MarineParser marineParser;
+
+        public SyntaxAnalyzer(PluginContainer pluginContainer = null)
+        {
+            if (pluginContainer == null)
+                pluginContainer = new PluginContainer();
+
+            marineParser = new MarineParser(pluginContainer);
+        }
 
         public IParseResult<ProgramAst> Parse(IEnumerable<Token> tokens)
         {

--- a/MarineLangUnitTest/Helper/VmCreateHelper.cs
+++ b/MarineLangUnitTest/Helper/VmCreateHelper.cs
@@ -4,6 +4,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using MarineLang.BuildInObjects;
 using MarineLang.LexicalAnalysis;
+using MarineLang.MacroPlugins;
+using MarineLang.PresetMacroPlugins;
 using MarineLang.Streams;
 using MarineLang.SyntaxAnalysis;
 using MarineLang.VirtualMachines;
@@ -16,7 +18,11 @@ namespace MarineLangUnitTest.Helper
         public static HighLevelVirtualMachine Create(string str)
         {
             var lexer = new LexicalAnalyzer();
-            var parser = new SyntaxAnalyzer();
+
+            var pluginContainer = new PluginContainer();
+            pluginContainer.AddFuncDefinitionPlugin("include", new IncludePlugin());
+
+            var parser = new SyntaxAnalyzer(pluginContainer);
 
             var tokens = lexer.GetTokens(str).ToArray();
             var tokenStream = TokenStream.Create(tokens);

--- a/MarineLangUnitTest/VirtualMachinePassTest.cs
+++ b/MarineLangUnitTest/VirtualMachinePassTest.cs
@@ -635,13 +635,21 @@ end", 1)]
 
         [Theory]
         [InlineData("#include{ \"hoge.mrn\" \"fuga.mrn\" } fun main() ret hoge() + fuga() end", 11)]
+        [InlineData("#include{ \"foobar.mrn\" } fun main() ret foo() + bar() end", 1100)]
         public void MacroTest<T>(string str, T expected)
         {
             using (var sw = new StreamWriter("hoge.mrn"))
-                sw.Write(@"fun hoge() ret 10 end");
+                sw.Write("fun hoge() ret 10 end");
 
             using (var sw = new StreamWriter("fuga.mrn"))
-                sw.Write(@"fun fuga() ret 1 end");
+                sw.Write("fun fuga() ret 1 end");
+
+            using (var sw = new StreamWriter("foo.mrn"))
+                sw.Write("fun foo() ret 100 end");
+
+            using (var sw = new StreamWriter("foobar.mrn"))
+                sw.Write("#include{ \"foo.mrn\" } fun bar() ret 1000 end");
+
 
             RunReturnCheck(str, expected);
         }

--- a/MarineLangUnitTest/VirtualMachinePassTest.cs
+++ b/MarineLangUnitTest/VirtualMachinePassTest.cs
@@ -1,5 +1,6 @@
 using MarineLang.BuiltInTypes;
 using MarineLangUnitTest.Helper;
+using System.IO;
 using Xunit;
 
 namespace MarineLangUnitTest
@@ -629,6 +630,19 @@ end", 1)]
         [InlineData("fun main() ret (OpSample1.new(5) + OpSample1.new(4)).v end", 9)]
         public void OperatorOverLoadTest<T>(string str, T expected)
         {
+            RunReturnCheck(str, expected);
+        }
+
+        [Theory]
+        [InlineData("#include{ \"hoge.mrn\" \"fuga.mrn\" } fun main() ret hoge() + fuga() end", 11)]
+        public void MacroTest<T>(string str, T expected)
+        {
+            using (var sw = new StreamWriter("hoge.mrn"))
+                sw.Write(@"fun hoge() ret 10 end");
+
+            using (var sw = new StreamWriter("fuga.mrn"))
+                sw.Write(@"fun fuga() ret 1 end");
+
             RunReturnCheck(str, expected);
         }
     }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ end
 ## EBNF
 
 ```ebnf
-program        = {func_definition} ;
+program        = {func_definition | macro} ;
 func_definition
                = 'func' , id , variable_list , func_body , 'end' ;
 func_body      = {statement} ;
@@ -103,7 +103,7 @@ param_list     = '(' , [ expr , { ',' , expr } ] , ')' ;
 variable_list  = '(' , [ variable , { ',' , variable } ] , ')' ;
 action_variable_list  = '|' , [ variable , { ',' , variable } ] , '|' ;
 array_literal  = '[' [ expr , { ',' , expr } ] , [ ';' , int_literal ] , ']'
-
+macro          = macro_name , ? トークン文字列群 ? ;
 
 トークン
 
@@ -120,7 +120,8 @@ lower_letter   = ? 省略 ?;
 upper_letter   = ? 省略 ?;
 digit          = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' ;
 binary_op      = '<' | '<=' | '>' | '>=' | '&&' | '||' | '==' | '!=' | '+' | '-' | '*' | '/' | '%' ;
-unary_op      = '-' | '!' ;
+unary_op       = '-' | '!' ;
+macro_name     = '#' , {lower_letter | upper_letter | digit} ;
 
 
 スキップ


### PR DESCRIPTION
例
```
#include{ "hoge.mrn" "fuga.mrn" } 
fun main() 
    ret hoge() + fuga() 
end
```